### PR TITLE
Ghost public API site has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gatsby Source Ghost
 
-Source plugin for pulling data into Gatsby.js from the [Ghost Public API](https://api.ghost.org).
+Source plugin for pulling data into Gatsby.js from the [Ghost Public API](https://docs.ghost.org/api/).
 
 ## Install
 


### PR DESCRIPTION
Old link points to deprecated docs