### PR TITLE
Fixes 'filter by tag' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A common but tricky example of filtering posts by tag, can be achieved like this
 
 ```
 {
-  allGhostPost(filter: {tags: {elemMatch {slug: {eq: $slug}}}}) {
+  allGhostPost(filter: {tags: {elemMatch: {slug: {eq: $slug}}}}) {
     edges {
       node {
         slug


### PR DESCRIPTION
There is a missing `:` after `elemMatch` in the 'tag filter' example which makes it even "trickier" 😉

Other than that, so far so good! About to test out dynamic page rendering in my POC since the queries have been working as expected so far. Keep it up! 