### PR TITLE
Postcount for tags and authors

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,7 +2,7 @@ const GhostAPI = require('./api');
 const _ = require('lodash');
 const {PostNode, PageNode, TagNode, AuthorNode} = require('./nodes');
 
-const getPostsPerTaxonomie = function getPostsPerTaxonomie(posts, taxonomie) {
+const getPostCount = function getPostCount(posts, taxonomie) {
     let allTaxonomies = [];
 
     // Get all possible taxonimies that are being used and
@@ -29,8 +29,8 @@ exports.sourceNodes = ({boundActionCreators}, configOptions) => {
     return GhostAPI
         .fetchAllPosts(configOptions)
         .then((posts) => {
-            const tagPostCount = getPostsPerTaxonomie(posts, 'tags');
-            const authorPostCount = getPostsPerTaxonomie(posts, 'authors');
+            const tagPostCount = getPostCount(posts, 'tags');
+            const authorPostCount = getPostCount(posts, 'authors');
 
             posts.forEach((post) => {
                 if (post.page) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,26 @@
 const GhostAPI = require('./api');
+const _ = require('lodash');
 const {PostNode, PageNode, TagNode, AuthorNode} = require('./nodes');
+
+const getPostsCountPerTag = function getPostsCountPerTag(posts) {
+    let allTags = [];
+
+    // Get all possible tags that are being used
+    posts.forEach(post => allTags.push(post.tags));
+    allTags = _.flatten(allTags);
+    allTags = _.transform(_.uniqBy(allTags, tag => tag.id), (result, tag) => {
+        (result[tag.slug] || (result[tag.slug] = []));
+    }, []);
+
+    // collect all post slugs per tag
+    posts.forEach((post) => {
+        post.tags.forEach((tag) => {
+            allTags[tag.slug].push(post.slug);
+        });
+    });
+
+    return allTags;
+};
 
 exports.sourceNodes = ({boundActionCreators}, configOptions) => {
     const {createNode} = boundActionCreators;
@@ -7,6 +28,8 @@ exports.sourceNodes = ({boundActionCreators}, configOptions) => {
     return GhostAPI
         .fetchAllPosts(configOptions)
         .then((posts) => {
+            const tagPostCount = getPostsCountPerTag(posts);
+
             posts.forEach((post) => {
                 if (post.page) {
                     createNode(PageNode(post));
@@ -16,6 +39,9 @@ exports.sourceNodes = ({boundActionCreators}, configOptions) => {
 
                 if (post.tags) {
                     post.tags.forEach((tag) => {
+                        // find the number of posts that have this tag
+                        tag.postCount = tagPostCount[tag.slug].length;
+
                         createNode(TagNode(tag));
                     });
                 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "eslint": "5.3.0",
     "eslint-plugin-ghost": "0.0.26",
+    "lodash": "^4.17.11",
     "mocha": "5.2.0",
     "should": "13.2.3",
     "sinon": "6.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,6 +774,10 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"


### PR DESCRIPTION
no issue

In order to calculate pagination for `/tag/` and `/author/` taxonomies, we need to provide at least the number of posts, that a tag or author is related to.

This PR adds a new property `postCount` to the `TagNode` and `AuthorNode`, which contains the number of posts for such.

Added a new fn `getPostCount` which is past the `posts` result from the API requests, as well as the desired taxonomy (`tags` or `authors`) and will return an Object containing the number of posts per slug.

**Further explanation**: 
Creating pages and filling those with data are different steps in Gatsby:

- Creating the pages happens in `gatsby-node` with the `createPages` API method. That's where URLs are created. The starter for Ghost uses all four of the provided nodes to create URLs for posts, tags, authors, and pages. 

- Filling the pages happens in the templates themselves where the queries then get executes (given a specific context, e. g. `slug`)

When it comes to pagination, posts are easy to solve with a plugin. The reason for that is that there is a dedicated index page (`/`) that renders all posts (and for those, the pagination works out of the box with the plugin), as well as a single post page (`/:slug`). The index page simply queries all posts (in addition to certain pagination properties), whereas the single post page queries one specific post slug.

For tags and authors, the situation is a bit different, because we create pages based on those taxonomies, e. g. `/tag/:slug` and  `/author/:slug`) but at that time of URL creation we have no knowledge about the amount of posts and if we need to create a `/tag/:slug/page/2`, as we don't know how many posts are in this collection yet and how many pages we need for that specific taxonomy.

But the information about the amount of posts is only available after the query in the template executed, where we fetch all posts that contain the requested taxonomy slug. This PR solves exactly that problem of page creation, so we know at the right time, how many pages we have to create.

One other option would be to not use the `TagNode` as source, but the `PostNode` and create the tag pages with some workaround fn, which seemed too complicated.