### PR TITLE
✨ Settings node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,6 @@
 const GhostContentAPI = require('@tryghost/content-api');
 const Promise = require('bluebird');
-const {PostNode, PageNode, TagNode, AuthorNode} = require('./nodes');
+const {PostNode, PageNode, TagNode, AuthorNode, SettingsNode} = require('./nodes');
 
 exports.sourceNodes = ({boundActionCreators}, configOptions) => {
     const {createNode} = boundActionCreators;
@@ -43,5 +43,7 @@ exports.sourceNodes = ({boundActionCreators}, configOptions) => {
         });
     });
 
-    return Promise.all([fetchPosts, fetchPages, fetchTags, fetchAuthors]);
+    const fetchSettings = api.settings.browse().then(setting => createNode(SettingsNode(setting)));
+
+    return Promise.all([fetchPosts, fetchPages, fetchTags, fetchAuthors, fetchSettings]);
 };

--- a/nodes.js
+++ b/nodes.js
@@ -10,8 +10,10 @@ const POST = 'Post';
 const PAGE = 'Page';
 const TAG = 'Tag';
 const AUTHOR = 'Author';
+const SETTINGS = 'Settings';
 
 module.exports.PostNode = createNodeFactory(POST);
 module.exports.PageNode = createNodeFactory(PAGE);
 module.exports.TagNode = createNodeFactory(TAG);
 module.exports.AuthorNode = createNodeFactory(AUTHOR);
+module.exports.SettingsNode = createNodeFactory(SETTINGS);

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -33,12 +33,20 @@ describe('Basic Functionality ', function () {
             {name: 'Ghost Writer', id: '1', count: {posts: 1}},
             {name: 'Ghost Author', id: '2', count: {posts: 1}}
         ]);
+        const browseSettings = sinon.stub().resolves(
+            {
+                title: 'Ghost & Gatsby',
+                description: 'Thoughts, stories and ideas.',
+                navigation: [{label: 'Home', url: '/'}]
+            }
+        );
         const GhostContentApiStub = function () {
             return {
                 posts: {browse: browsePosts},
                 pages: {browse: browsePages},
                 tags: {browse: browseTags},
-                authors: {browse: browseAuthors}
+                authors: {browse: browseAuthors},
+                settings: {browse: browseSettings}
             };
         };
 
@@ -47,7 +55,7 @@ describe('Basic Functionality ', function () {
         gatsbyNode
             .sourceNodes({boundActionCreators: {createNode}}, {})
             .then(() => {
-                createNode.callCount.should.eql(6);
+                createNode.callCount.should.eql(7);
 
                 const getArg = call => createNode.getCall(call).args[0];
 
@@ -58,6 +66,7 @@ describe('Basic Functionality ', function () {
                 getArg(3).internal.should.have.property('type', 'GhostTag');
                 getArg(4).internal.should.have.property('type', 'GhostAuthor');
                 getArg(5).internal.should.have.property('type', 'GhostAuthor');
+                getArg(6).internal.should.have.property('type', 'GhostSettings');
 
                 done();
             })


### PR DESCRIPTION
no issue

- Connect to the settings endpoint via v2 Content API
- Create a `SettingsNode` which will be available as `GhostSettings` in Gatsby (_note_: naming in plural here is intentional, as we receive an Object of settings that, whereas for the other types we receive an Array of Object and create a node for each single post/tag/author/page)
- Added tests