### PR TITLE
remove unused lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "eslint": "5.3.0",
     "eslint-plugin-ghost": "0.0.26",
-    "lodash": "^4.17.11",
     "mocha": "5.2.0",
     "proxyquire": "^2.1.0",
     "should": "13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,7 +1060,7 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash@^4.16.4, lodash@^4.17.11:
+lodash@^4.16.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 


### PR DESCRIPTION
Y'all removed the need for lodash a few releases ago but didn't update `package.json`. Or maybe you were keeping it around for future use?