### PR TITLE
Secondary navigation added to schema per Ghost api v3

### DIFF
--- a/ghost-schema.js
+++ b/ghost-schema.js
@@ -121,6 +121,12 @@ const settings = {
         {label: 'Tag', url: '/tag/getting-started/'},
         {label: 'Author', url: '/author/ghost/'},
         {label: 'Help', url: 'https://help.ghost.org'}
+    ],
+    secondary_navigation: [
+        {label: 'Home', url: '/'},
+        {label: 'Tag', url: '/tag/getting-started/'},
+        {label: 'Author', url: '/author/ghost/'},
+        {label: 'Help', url: 'https://help.ghost.org'}
     ]
 };
 


### PR DESCRIPTION
Ghost api v3 provides secondary navigation so the schema can be updated to reflect the api.