### PR TITLE
Add url to settings schema to conform to Ghost api v3

### DIFF
--- a/ghost-schema.js
+++ b/ghost-schema.js
@@ -121,7 +121,8 @@ const settings = {
         {label: 'Tag', url: '/tag/getting-started/'},
         {label: 'Author', url: '/author/ghost/'},
         {label: 'Help', url: 'https://help.ghost.org'}
-    ]
+    ],
+    url: 'https://demo.ghost.io/'
 };
 
 module.exports = {


### PR DESCRIPTION
Ghost api v3 for settings includes a field for url so the schema should also include this field.

https://ghost.org/docs/api/v3/content/#settings