### PR TITLE
Ghost v4

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -111,7 +111,7 @@ exports.sourceNodes = ({actions}, configOptions) => {
 
     const postAndPageFetchOptions = {
         limit: 'all',
-        include: 'tags,authors',
+        include: 'tags,authors,feature_image_alt,feature_image_caption',
         formats: 'html,plaintext'
     };
 

--- a/ghost-schema.js
+++ b/ghost-schema.js
@@ -1,5 +1,5 @@
 /**
- * Custom schema with types based on the Ghost V3 API spec.
+ * Custom schema with types based on the Ghost V4 API spec.
  *
  * Note that GhostPost and GhostPage are identical.
  *
@@ -18,6 +18,8 @@ type GhostPost implements Node {
     html: String
     comment_id: String
     feature_image: String
+    feature_image_caption: String
+    feature_image_alt: String
     featured: Boolean!
     visibility: String!
     created_at: Date! @dateformat
@@ -59,6 +61,8 @@ type GhostPage implements Node {
     html: String
     comment_id: String
     feature_image: String
+    feature_image_caption: String
+    feature_image_alt: String
     featured: Boolean!
     visibility: String!
     created_at: Date! @dateformat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-ghost",
-  "version": "4.3.0",
+  "version": "4.2.4",
   "description": "Gatsby source plugin for building websites using the Ghost API as a data source.",
   "repository": "git@github.com:TryGhost/gatsby-source-ghost.git",
   "author": "Ghost Foundation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-ghost",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "description": "Gatsby source plugin for building websites using the Ghost API as a data source.",
   "repository": "git@github.com:TryGhost/gatsby-source-ghost.git",
   "author": "Ghost Foundation",


### PR DESCRIPTION
Addresses [Issue 191](https://github.com/TryGhost/gatsby-source-ghost/issues/191) by adding `feature_image_alt` and `feature_image_caption` as per the v4 schema. I think this may be a breaking change for users of v3 and lower, so any feedback is appreciated