### PR TITLE
added support for node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby-source-plugin"
   ],
   "engines": {
-    "node": "12.x || 14.x || 16.x || 18.x"
+    "node": "12.x || 14.x || 16.x || 18.x || 20.x"
   },
   "scripts": {
     "lint": "eslint . --ext .js --cache",


### PR DESCRIPTION
Hello guys, we're currently using this plugin in our project.

We have updated our node version to 20, but we're getting a warning. I've ran several tests with this library to confirm that it doesn't break on node 20. It's safe to update.

I'd like to stop getting this warning every time I compile my webapp. 

Thanks in advance, 
Chris.

![image](https://github.com/TryGhost/gatsby-source-ghost/assets/159506618/125804d3-1676-4dbb-8ece-e4b0a24cd10f)
